### PR TITLE
feat(blog): add reading-time shortcode and partial

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -25,6 +25,7 @@
       {{- partial "translation_list.html" . -}}
       {{- partial "edit_post.html" . -}}
       {{- partial "post_canonical.html" . -}}
+      <span class="post-reading-time">· {{ partial "reading-time.html" . }}</span>
     </div>
     {{- end }}
   </header>

--- a/layouts/partials/reading-time.html
+++ b/layouts/partials/reading-time.html
@@ -1,0 +1,11 @@
+{{- /* reading-time partial: displays estimated reading time for use in layouts */ -}}
+{{- $wordCount := .Content | countwords -}}
+{{- $readingSpeed := 200 -}}
+{{- $minutes := div $wordCount $readingSpeed -}}
+{{- if gt (mod $wordCount $readingSpeed) 0 -}}
+  {{- $minutes = add $minutes 1 -}}
+{{- end -}}
+{{- if lt $minutes 1 -}}
+  {{- $minutes = 1 -}}
+{{- end -}}
+{{- $minutes }} min read

--- a/layouts/shortcodes/reading-time.html
+++ b/layouts/shortcodes/reading-time.html
@@ -1,0 +1,11 @@
+{{- /* reading-time shortcode: displays estimated reading time */ -}}
+{{- $wordCount := .Page.Content | countwords -}}
+{{- $readingSpeed := 200 -}}
+{{- $minutes := div $wordCount $readingSpeed -}}
+{{- if gt (mod $wordCount $readingSpeed) 0 -}}
+  {{- $minutes = add $minutes 1 -}}
+{{- end -}}
+{{- if lt $minutes 1 -}}
+  {{- $minutes = 1 -}}
+{{- end -}}
+{{- $minutes }} min read


### PR DESCRIPTION
## Summary
Adds a Hugo shortcode (`{{< reading-time >}}`) and partial that displays the estimated reading time for blog posts.

## Changes
- **New shortcode:** `layouts/shortcodes/reading-time.html` — for use in content files
- **New partial:** `layouts/partials/reading-time.html` — for use in layout templates
- **Updated:** `layouts/_default/single.html` — displays reading time in post meta (e.g., "· 5 min read")
- Calculates based on 200 words/min, rounded up, minimum 1 min

## Testing
1. Run `hugo server` to start the dev server
2. Open any blog post — reading time should appear in the header meta
3. Verify different length posts show appropriate reading times
4. Verify minimum of 1 min read for very short content

Closes: #17