### PR TITLE
feat(homepage): make homepage text more engaging in French and English

### DIFF
--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -1,3 +1,36 @@
+/* Homepage content styling */
+.home-content {
+    max-width: var(--nav-width, 800px);
+    margin: 0 auto;
+    padding: 1rem 1.5rem 2rem;
+    text-align: center;
+    line-height: 1.8;
+}
+
+.home-content ul {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem 1.5rem;
+    margin: 1.5rem 0;
+}
+
+.home-content ul li {
+    margin: 0;
+    font-size: 0.95rem;
+}
+
+.home-content p:first-child {
+    font-size: 1.1rem;
+    font-weight: 500;
+}
+
+.home-content a {
+    font-weight: 600;
+}
+
 .mermaid {
     background-color: rgb(245, 245, 245) !important;
 }

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,0 +1,17 @@
+---
+title: "Hot coffee - devBlog ☕"
+description: "The blog of a passionate developer — Java, DevOps, and best practices"
+---
+
+Welcome to *Hot coffee — devBlog*! 🎉
+
+Here you'll find technical articles, hands-on experience reports, and tips about:
+
+- ☕ **Java & JVM** — from Jakarta EE to GraalVM, including JEP deep-dives
+- 🐳 **DevOps & Tooling** — Docker, CI/CD, Git, automation
+- 🛠️ **Software engineering** — architecture, best practices, productivity
+- 🤖 **Devoxx & conferences** — summaries and discoveries
+
+Whether you're a junior or a senior developer, grab a coffee ☕, sit back, and happy reading!
+
+To stay up to date, subscribe to the [RSS feed](/en/index.xml) or follow me on socials below.

--- a/content/fr/_index.md
+++ b/content/fr/_index.md
@@ -1,0 +1,17 @@
+---
+title: "Hot coffee - devBlog ☕"
+description: "Le blog d'un développeur passionné — Java, DevOps, et bonnes pratiques"
+---
+
+Bienvenue sur *Hot coffee — devBlog* ! 🎉
+
+Ici, tu trouveras des articles techniques, des retours d'expérience, et des astuces sur :
+
+- ☕ **Java & JVM** — de Jakarta EE à GraalVM, en passant par les JEP
+- 🐳 **DevOps & Tooling** — Docker, CI/CD, Git, automatisation
+- 🛠️ **Développement logiciel** — architecture, bonnes pratiques, productivité
+- 🤖 **Devoxx & conférences** — comptes-rendus et découvertes
+
+Que tu sois junior ou senior, prends un café ☕, installe-toi, et bonne lecture !
+
+Pour ne rien rater, abonne-toi au [flux RSS](/fr/index.xml) ou suis-moi sur les réseaux ci-dessous.

--- a/hugo.yml
+++ b/hugo.yml
@@ -30,7 +30,7 @@ languages:
           url: /search
           weight: 2
     params:
-      subtitle: "Just another dev blog."
+      subtitle: "A passionate developer sharing knowledge, tips, and insights about **Java**, **DevOps**, and **software engineering** — one cup of coffee at a time. ☕"
       buttons:
       - name: Blog
         url: "blog"
@@ -55,7 +55,7 @@ languages:
           url: search
           weight: 2
     params:
-      subtitle: "Juste un blog de dev."
+      subtitle: "Un développeur passionné partageant connaissances, astuces et réflexions sur **Java**, **DevOps** et le **développement logiciel** — un café à la fois. ☕"
       buttons:
       - name: Blog
         url: "blog"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,126 @@
+{{- define "main" }}
+
+{{- if (and site.Params.profileMode.enabled .IsHome) }}
+{{- partial "index_profile.html" . }}
+
+{{- if .Content }}
+<div class="post-content home-content md-content">
+  {{- partial "anchored_headings.html" .Content -}}
+</div>
+{{- end }}
+
+{{- else }} {{/* if not profileMode */}}
+
+{{- if not .IsHome | and .Title }}
+<header class="page-header">
+  {{- partial "breadcrumbs.html" . }}
+  <h1>
+    {{ .Title }}
+    {{- if and (or (eq .Kind `term`) (eq .Kind `section`)) (.Param "ShowRssButtonInSectionTermList") }}
+    {{- with .OutputFormats.Get "rss" }}
+    <a href="{{ .RelPermalink }}" title="RSS" aria-label="RSS">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+        stroke-linecap="round" stroke-linejoin="round" height="23">
+        <path d="M4 11a9 9 0 0 1 9 9" />
+        <path d="M4 4a16 16 0 0 1 16 16" />
+        <circle cx="5" cy="19" r="1" />
+      </svg>
+    </a>
+    {{- end }}
+    {{- end }}
+  </h1>
+  {{- if .Description }}
+  <div class="post-description">
+    {{ .Description | markdownify }}
+  </div>
+  {{- end }}
+</header>
+{{- end }}
+
+{{- if .Content }}
+<div class="post-content md-content">
+  {{- partial "anchored_headings.html" .Content -}}
+</div>
+{{- end }}
+
+{{- $pages := union .RegularPages .Sections }}
+
+{{- if .IsHome }}
+{{- $pages = where site.RegularPages "Type" "in" site.Params.mainSections }}
+{{- $pages = where $pages "Params.hiddenInHomeList" "!=" "true"  }}
+{{- end }}
+
+{{- $paginator := .Paginate $pages }}
+
+{{- if and .IsHome site.Params.homeInfoParams (eq $paginator.PageNumber 1) }}
+{{- partial "home_info.html" . }}
+{{- end }}
+
+{{- $term := .Data.Term }}
+{{- range $index, $page := $paginator.Pages }}
+
+{{- $class := "post-entry" }}
+
+{{- $user_preferred := or site.Params.disableSpecial1stPost site.Params.homeInfoParams }}
+{{- if (and $.IsHome (eq $paginator.PageNumber 1) (eq $index 0) (not $user_preferred)) }}
+{{- $class = "first-entry" }}
+{{- else if $term }}
+{{- $class = "post-entry tag-entry" }}
+{{- end }}
+
+<article class="{{ $class }}">
+  {{- $isHidden := (.Param "cover.hiddenInList") | default (.Param "cover.hidden") | default false }}
+  {{- partial "cover.html" (dict "cxt" . "IsSingle" false "isHidden" $isHidden) }}
+  <header class="entry-header">
+    <h2 class="entry-hint-parent">
+      {{- .Title }}
+      {{- if .Draft }}
+      <span class="entry-hint" title="Draft">
+        <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 -960 960 960" fill="currentColor">
+          <path
+            d="M160-410v-60h300v60H160Zm0-165v-60h470v60H160Zm0-165v-60h470v60H160Zm360 580v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q9 9 13 20t4 22q0 11-4.5 22.5T862.09-380L643-160H520Zm300-263-37-37 37 37ZM580-220h38l121-122-18-19-19-18-122 121v38Zm141-141-19-18 37 37-18-19Z" />
+        </svg>
+      </span>
+      {{- end }}
+    </h2>
+  </header>
+  {{- if (ne (.Param "hideSummary") true) }}
+  <div class="entry-content">
+    <p>{{ .Summary | plainify | htmlUnescape }}{{ if .Truncated }}...{{ end }}</p>
+  </div>
+  {{- end }}
+  {{- if not (.Param "hideMeta") }}
+  <footer class="entry-footer">
+    {{- partial "post_meta.html" . -}}
+  </footer>
+  {{- end }}
+  <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
+</article>
+{{- end }}
+
+{{- if gt $paginator.TotalPages 1 }}
+<footer class="page-footer">
+  <nav class="pagination">
+    {{- if $paginator.HasPrev }}
+    <a class="prev" href="{{ $paginator.Prev.URL | absURL }}">
+      «&nbsp;{{ i18n "prev_page" }}&nbsp;
+      {{- if (.Param "ShowPageNums") }}
+      {{- sub $paginator.PageNumber 1 }}/{{ $paginator.TotalPages }}
+      {{- end }}
+    </a>
+    {{- end }}
+    {{- if $paginator.HasNext }}
+    <a class="next" href="{{ $paginator.Next.URL | absURL }}">
+      {{- i18n "next_page" }}&nbsp;
+      {{- if (.Param "ShowPageNums") }}
+      {{- add 1 $paginator.PageNumber }}/{{ $paginator.TotalPages }}
+      {{- end }}&nbsp;»
+    </a>
+    {{- end }}
+  </nav>
+</footer>
+{{- end }}
+
+{{- end }}{{/* end profileMode */}}
+
+{{- end }}{{- /* end main */ -}}

--- a/layouts/partials/index_profile.html
+++ b/layouts/partials/index_profile.html
@@ -31,7 +31,7 @@
         {{- end }}
         {{- end }}
         <h1>{{ .title | default site.Title | markdownify }}</h1>
-        <span>{{ site.Language.Params.subtitle }}</span>
+        <span>{{ site.Language.Params.subtitle | markdownify }}</span>
         {{- partial "social_icons.html" -}}
 
         {{- with site.Language.Params.buttons }}


### PR DESCRIPTION
## Summary

Refresh the homepage with more engaging, welcoming text in both French and English. The homepage now clearly communicates the blog's focus areas (Java, DevOps, software engineering) with a friendly, inviting tone.

## Changes

### Configuration
- **`hugo.yml`** — Updated French and English subtitles from generic text to engaging, descriptive taglines

### New Content
- **`content/fr/_index.md`** — French homepage content with welcoming intro, topic list, and RSS link
- **`content/en/_index.md`** — English homepage content with welcoming intro, topic list, and RSS link

### Templates
- **`layouts/_default/list.html`** — Override PaperMod's list template to render `_index.md` content alongside the profile mode section
- **`layouts/partials/index_profile.html`** — Added `markdownify` filter to subtitle for rich text formatting support

### Styling
- **`assets/css/extended/custom.css`** — Added `.home-content` styles for centered, readable homepage content layout

## Testing

1. **Verify the build**:
   ```bash
   hugo --minify
   ```

2. **Check the French homepage** (`http://localhost:1313/`):
   - Profile section shows: "Un développeur passionné partageant connaissances, astuces et réflexions sur **Java**, **DevOps** et le **développement logiciel** — un café à la fois. ☕"
   - Below: welcoming text with topic list and RSS link

3. **Check the English homepage** (`http://localhost:1313/en/`):
   - Profile section shows: "A passionate developer sharing knowledge, tips, and insights about **Java**, **DevOps**, and **software engineering** — one cup of coffee at a time. ☕"
   - Below: welcoming text with topic list and RSS link

4. **Responsive check**: Ensure the homepage content wraps nicely on mobile

Closes: #24
