### PR TITLE
feat(homepage): rewrite homepage copy in FR & EN for better engagement

### DIFF
--- a/hugo.yml
+++ b/hugo.yml
@@ -30,11 +30,13 @@ languages:
           url: /search
           weight: 2
     params:
-      subtitle: "Just another dev blog."
+      subtitle: "Notes from a passionate developer — Java · DevOps · Software Craftsmanship"
+      profileMode:
+        title: "Hi, I'm Ivan 👋"
       buttons:
-      - name: Blog
+      - name: 📖 Read the Blog
         url: "blog"
-      - name: "Who am I?"
+      - name: "👤 About me"
         url: "https://github.com/ibethus"
   fr:
     disabled: false
@@ -55,11 +57,13 @@ languages:
           url: search
           weight: 2
     params:
-      subtitle: "Juste un blog de dev."
+      subtitle: "Notes d'un développeur passionné — Java · DevOps · Artisanat logiciel"
+      profileMode:
+        title: "Bonjour, je suis Ivan 👋"
       buttons:
-      - name: Blog
+      - name: 📖 Lire le Blog
         url: "blog"
-      - name: Qui suis-je ?
+      - name: "👤 À propos de moi"
         url: "https://github.com/ibethus"
 markup:
   goldmark:
@@ -105,7 +109,11 @@ params:
   label:
     text: Hot coffee - devBlog ☕
   profileMode:
-    enabled: true    
+    enabled: true
+    imageUrl: "https://github.com/ibethus.png"
+    imageTitle: "Ivan Béthus"
+    imageWidth: 120
+    imageHeight: 120
   socialIcons: 
     - name: github
       url: "https://github.com/ibethus?tab=repositories/"


### PR DESCRIPTION
## Summary

Rewrites the homepage copy for both French and English versions of the blog to make it more engaging and personal. Replaces generic placeholder text with descriptive, welcoming content that immediately communicates Ivan's tech focus and personality.

## Changes

| File | What changed |
|------|-------------|
| `hugo.yml` | Updated `languages.fr.params.subtitle`, `languages.en.params.subtitle`, per-language `profileMode.title`, CTA button labels, and added GitHub avatar via `profileMode.imageUrl` |

**Before:**
- 🇫🇷 Subtitle: *"Juste un blog de dev."*
- 🇬🇧 Subtitle: *"Just another dev blog."*
- Buttons: plain "Blog" / "Who am I?"

**After:**
- 🇫🇷 Subtitle: *"Notes d'un développeur passionné — Java · DevOps · Artisanat logiciel"*
- 🇬🇧 Subtitle: *"Notes from a passionate developer — Java · DevOps · Software Craftsmanship"*
- 🇫🇷 Title: *"Bonjour, je suis Ivan 👋"*
- 🇬🇧 Title: *"Hi, I'm Ivan 👋"*
- Buttons: emoji-enhanced CTAs with localised labels
- GitHub profile avatar displayed on homepage

## Testing

1. Checkout the branch:
   ```bash
   git checkout feat/28-nouvelle-page-accueil
   ```
2. Run the Hugo dev server:
   ```bash
   hugo server
   ```
3. Open http://localhost:1313/ — verify **French** homepage shows the new greeting and tagline.
4. Switch to English (language toggle) at http://localhost:1313/en/ — verify **English** content is correct.
5. Verify the build produces no errors:
   ```bash
   hugo --minify
   ```

Closes: #28
