### PR TITLE
feat(typography): add funky typography with Bangers and Space Grotesk

### DIFF
--- a/assets/css/extended/fonts.css
+++ b/assets/css/extended/fonts.css
@@ -1,0 +1,106 @@
+/*
+ * Funky typography overrides for PaperMod
+ * Fonts loaded via layouts/partials/extend_head.html:
+ *   - Bangers (display/headings)
+ *   - Space Grotesk (body)
+ *   - JetBrains Mono (code)
+ */
+
+body {
+    font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-weight: 400;
+    letter-spacing: 0.01em;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-family: 'Bangers', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-weight: 400;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+h1 {
+    font-size: 3.2rem;
+    line-height: 1.1;
+}
+
+h2 {
+    font-size: 2.4rem;
+    line-height: 1.15;
+}
+
+h3 {
+    font-size: 1.8rem;
+    line-height: 1.2;
+}
+
+h4 {
+    font-size: 1.4rem;
+    line-height: 1.25;
+}
+
+/* Make the site title in the header use Bangers too */
+.logo a,
+.site-title {
+    font-family: 'Bangers', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
+    font-size: 1.6rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+/* Code blocks in JetBrains Mono */
+code,
+pre,
+kbd,
+samp {
+    font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+    font-size: 0.9em;
+}
+
+/* Post meta and navigation */
+.post-meta,
+.nav a,
+.pagination a,
+.terms a,
+.tag a,
+.page-footer a,
+.menu a {
+    font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-weight: 500;
+}
+
+/* Entry titles on listing pages */
+.entry-title {
+    font-family: 'Bangers', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
+    font-weight: 400;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-size: 1.8rem;
+}
+
+/* Profile mode name */
+.profile-mode .profile_inner h1 {
+    font-family: 'Bangers', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
+    font-size: 3.6rem;
+    letter-spacing: 0.1em;
+}
+
+/* Subtitle in profile mode */
+.profile-mode .profile_inner .subtitle {
+    font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-weight: 500;
+    font-size: 1.2rem;
+}
+
+/* Buttons */
+.button,
+.btn {
+    font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+}


### PR DESCRIPTION
## Summary

Applied a funky typography to the site using the Google Fonts already loaded in the theme's `extend_head.html`. The site now uses **Bangers** (a bold comic-style display font) for headings and titles, **Space Grotesk** (a modern sans-serif) for body text, and **JetBrains Mono** for code blocks.

## Changes

- **`assets/css/extended/fonts.css`** (new) — PaperMod extension stylesheet that overrides font families:
  - Body: `Space Grotesk` (smooth, readable sans-serif)
  - Headings (h1–h6), site title, entry titles: `Bangers` (bold, uppercase, funky comic-style display)
  - Code blocks: `JetBrains Mono` (developer-friendly monospace with ligatures)
  - Navigation, meta, buttons: `Space Grotesk` (weight 500–600)

## Testing

1. Visit the site and verify:
   - **Headings** (h1–h6) render in Bangers font (bold, uppercase, comic-style)
   - **Body text** renders in Space Grotesk
   - **Code blocks** render in JetBrains Mono
   - **Site title** in the header uses Bangers
   - All pages load correctly (home, blog posts, tags, categories, 404)

2. Run the Hugo build:
   ```bash
   hugo --minify
   ```
   The build should complete with 0 errors.

Closes: #27
