### PR TITLE
feat(homepage): add engaging welcome text in French and English

### DIFF
--- a/assets/css/extended/homepage.css
+++ b/assets/css/extended/homepage.css
@@ -1,0 +1,22 @@
+/* Custom styling for the homepage welcome section */
+.profile-separator {
+    margin: 2rem auto;
+    width: 80%;
+    max-width: 200px;
+    border: none;
+    height: 1px;
+    background: linear-gradient(to right, transparent, var(--border), transparent);
+}
+
+.profile .post-content {
+    text-align: center;
+    max-width: 700px;
+    margin: 0 auto;
+    padding: 0 1rem;
+}
+
+.profile .post-content p {
+    margin: 1rem 0;
+    line-height: 1.8;
+    font-size: 1.1rem;
+}

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,0 +1,11 @@
+---
+title: Hot coffee - devBlog ☕
+---
+
+Welcome to my developer blog! ☕
+
+I'm Ivan Béthus, a software engineer passionate about software engineering, DevOps, and platform engineering. Here, I share hands-on experience, tutorials, and thoughts about the technologies shaping our craft.
+
+Whether you're a first-time visitor or a regular reader, I hope you'll find inspiration and useful insights. Dive into the articles, explore the categories, and feel free to reach out for a chat!
+
+Happy reading! 🚀

--- a/content/fr/_index.md
+++ b/content/fr/_index.md
@@ -1,0 +1,11 @@
+---
+title: Hot coffee - devBlog ☕
+---
+
+Bienvenue sur mon blog développeur ! ☕
+
+Je suis Ivan Béthus, développeur passionné par le génie logiciel, le DevOps et l'ingénierie de plateforme. Ici, je partage des retours d'expérience, des tutoriels et des réflexions sur les technologies qui façonnent notre métier.
+
+Que vous soyez ici pour la première fois ou un lecteur assidu, j'espère que vous trouverez de l'inspiration et des connaissances utiles. Plongez dans les articles, explorez les catégories, et n'hésitez pas à me contacter pour échanger !
+
+Bonne lecture ! 🚀

--- a/layouts/partials/index_profile.html
+++ b/layouts/partials/index_profile.html
@@ -55,4 +55,10 @@
         {{- end }}
     </div>
     {{- end}}
+    {{- with .Content }}
+    <hr class="profile-separator">
+    <div class="post-content">
+        {{ . }}
+    </div>
+    {{- end }}
 </div>


### PR DESCRIPTION
## Summary

Add engaging welcome/introduction text to the homepage in both French and English, making the landing page more personal and inviting for visitors.

## Changes

### New files
- `content/fr/_index.md` — French welcome text introducing the author and blog purpose
- `content/en/_index.md` — English welcome text introducing the author and blog purpose  
- `assets/css/extended/homepage.css` — Custom styling for the profile separator and welcome content section

### Modified files
- `layouts/partials/index_profile.html` — Added rendering of page `.Content` below the profile section, with a visual `<hr>` separator

## Testing

1. **Build**: `hugo --minify` — must succeed with no errors
2. **Verify French homepage**: Open `public/index.html` — should show the profile section, then a subtle separator, then the French welcome paragraph ("Bienvenue sur mon blog développeur ! ☕")
3. **Verify English homepage**: Open `public/en/index.html` — should show the same layout with the English welcome paragraph ("Welcome to my developer blog! ☕")
4. **Verify language switching still works**: The language switcher in the header should toggle between French and English homepages correctly
5. **Verify blog listing still works**: Navigate to `/blog` and `/en/blog/` — blog posts should still be listed as before

Closes: #31
