### PR TITLE
feat(typography): change site typography to funky Google Fonts

### DIFF
--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -1,0 +1,157 @@
+/*
+ * Funky typography for Hot Coffee devBlog ☕
+ * Fonts loaded via Google Fonts in layouts/partials/extend_head.html:
+ *   - Bangers: Bold display font for headings
+ *   - Space Grotesk: Modern sans-serif for body text
+ *   - JetBrains Mono: Coding font for code blocks
+ */
+
+/* ── Body text: Space Grotesk ── */
+body {
+    font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-size: 18px;
+    line-height: 1.7;
+    letter-spacing: 0.01em;
+}
+
+/* ── Headings: Bangers (funky!) ── */
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Bangers', Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
+    font-weight: 400;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+h1 {
+    font-size: 2.8rem;
+    word-break: break-word;
+}
+
+h2 {
+    font-size: 2.2rem;
+}
+
+h3 {
+    font-size: 1.8rem;
+}
+
+h4 {
+    font-size: 1.5rem;
+}
+
+h5 {
+    font-size: 1.3rem;
+}
+
+h6 {
+    font-size: 1.1rem;
+}
+
+/* ── Site title / branding ── */
+.logo a {
+    font-family: 'Bangers', Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
+    font-size: 1.8rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--primary);
+}
+
+/* ── Profile mode (homepage) ── */
+.profile .profile_inner h1 {
+    font-family: 'Bangers', Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
+    font-size: 3.5rem;
+    letter-spacing: 0.08em;
+    word-break: break-word;
+}
+
+/* ── Subtitle ── */
+.profile .profile_inner .subtitle {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 1.1rem;
+    letter-spacing: 0.02em;
+    opacity: 0.85;
+}
+
+/* ── Navigation / menu ── */
+.nav a {
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+}
+
+/* ── Code blocks: JetBrains Mono ── */
+code, pre, .highlight {
+    font-family: 'JetBrains Mono', 'SF Mono', Monaco, 'Cascadia Code', 'Fira Code', 'Consolas', 'Courier New', monospace;
+    font-size: 0.9em;
+}
+
+/* ── Post content ── */
+.post-content {
+    font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    line-height: 1.8;
+}
+
+/* ── Buttons (funky flair) ── */
+.buttons a {
+    font-family: 'Bangers', Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
+    font-size: 1.2rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    padding: 12px 28px;
+    border-radius: 50px;
+    transition: all 0.2s ease;
+}
+
+.buttons a:hover {
+    transform: scale(1.05);
+}
+
+/* ── Entry titles in list ── */
+.entry-header h2 {
+    font-family: 'Bangers', Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
+    font-size: 1.8rem;
+    letter-spacing: 0.04em;
+}
+
+/* ── Footer ── */
+.footer {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 0.9rem;
+    letter-spacing: 0.02em;
+}
+
+/* ── Pagination ── */
+.pagination a {
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+}
+
+/* ── Tags and categories ── */
+.terms a,
+.tag a,
+.categories a {
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+}
+
+/* ── Table of contents ── */
+.toc a {
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 500;
+}
+
+/* ── Post meta (date, reading time, etc.) ── */
+.post-meta {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
+    opacity: 0.8;
+}
+
+/* ── Search page ── */
+.search-entry .entry-title {
+    font-family: 'Bangers', Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
+    letter-spacing: 0.04em;
+}


### PR DESCRIPTION
## Summary

Change the site typography to be more funky using Google Fonts that were already loaded in `extend_head.html` but never actually applied to the CSS.

The fonts used:
- **Bangers** — bold, playful display font for all headings and branding
- **Space Grotesk** — modern, distinctive sans-serif for body text and navigation
- **JetBrains Mono** — clean coding font for code blocks

## Changes

| File | Description |
|------|-------------|
| `assets/css/extended/custom.css` | **New file** — Custom CSS bundle applied via PaperMod's extended CSS system. Uses Hugo's asset pipeline (`resources.Match "css/extended/*.css"`) to get automatically concatenated into the final stylesheet. |

### Font mapping
- **Headings (h1-h6)**: `Bangers` with uppercase transform and letter-spacing
- **Body / post content**: `Space Grotesk` with improved line-height (1.7→1.8)
- **Code**: `JetBrains Mono` with fallbacks
- **Site logo / branding**: `Bangers`
- **Navigation, meta, footer**: `Space Grotesk`
- **Buttons**: `Bangers` with pill shape and hover scale effect

## Testing

1. Build the site: `hugo --minify`
2. Open any page in a browser
3. Verify headings display in **Bangers** (bold, comic-style font)
4. Verify body text displays in **Space Grotesk** (modern sans-serif)
5. Verify code blocks display in **JetBrains Mono** (monospace with coding ligatures)
6. Check that the site remains fully responsive and readable

Closes: #32
