### PR TITLE
feat(ui): change site typography to funky Google Fonts

### DIFF
--- a/assets/css/extended/typography.css
+++ b/assets/css/extended/typography.css
@@ -1,0 +1,58 @@
+/* 
+ * Funky Typography — Ticket #37
+ * 
+ * Google Fonts loaded via layouts/partials/extend_head.html:
+ *   - Bangers (display / funky headings)
+ *   - Space Grotesk (body text)
+ *   - JetBrains Mono (code)
+ */
+
+/* ── Body text ── */
+body {
+    font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+}
+
+/* ── Headings ── */
+h1, h2, h3, h4, h5, h6,
+.post-title,
+.entry-header h1,
+.entry-header h2,
+.logo a {
+    font-family: 'Bangers', cursive;
+    letter-spacing: 0.04em;
+    font-weight: 400;
+}
+
+/* Slightly adjust heading sizes for Bangers since it's an all-caps display font */
+h1, .post-title, .post-content h1 {
+    font-size: 48px;
+}
+
+.post-content h2 {
+    font-size: 36px;
+}
+
+.post-content h3 {
+    font-size: 28px;
+}
+
+.entry-header h1 {
+    font-size: 40px;
+}
+
+.entry-header h2 {
+    font-size: 28px;
+}
+
+/* ── Logo / site title ── */
+.logo a {
+    font-size: 28px;
+}
+
+/* ── Code blocks ── */
+code,
+pre,
+.post-content code,
+.post-content pre code {
+    font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+}


### PR DESCRIPTION
## Summary

Change the site typography to be more funky by applying the Google Fonts already loaded in the head section.

### What was done

Applied three Google Fonts via custom CSS in `assets/css/extended/typography.css`:
- **Bangers** — applied to all headings (h1–h6), post titles, entry headers, and the site logo for a funky/display look
- **Space Grotesk** — applied to body text as the primary sans-serif font
- **JetBrains Mono** — applied to all code and pre elements for improved code readability

## Changes

| File | Description |
|------|-------------|
| `assets/css/extended/typography.css` | New custom stylesheet bundled by PaperMod theme. Overrides font families and adjusts heading sizes for the new display font. |

## Testing

1. Run `hugo --minify` to verify the build passes
2. Open the site and verify:
   - Headings are rendered in **Bangers** font (funky, all-caps display font)
   - Body text uses **Space Grotesk**
   - Code blocks use **JetBrains Mono**
3. Check both light and dark themes
4. Verify that the CSS is bundled in the minified output: `public/assets/css/stylesheet.*.css` should contain `bangers`, `space grotesk`, and `jetbrains mono`

Closes: #37
